### PR TITLE
check logger before closing polyglot logger

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LoggingPolyglot"
 uuid = "211639cc-9b11-4cfd-abc6-8f7477829344"
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/logs.jl
+++ b/src/logs.jl
@@ -32,7 +32,9 @@ function fatal_error(
     @logmsg FATAL_ERROR_LEVEL msg
 
     logger = Logging.global_logger()
-    close_polyglot_logger(logger)
+    if logger isa LoggingExtras.TeeLogger
+        close_polyglot_logger(logger)
+    end
     throw(exception)
     return nothing
 end


### PR DESCRIPTION
Fixes error when `LoggingPolyglot.fatal_error` is called before creating a Polyglot log.